### PR TITLE
Faster build times and smaller image

### DIFF
--- a/base-devel.dockerfile
+++ b/base-devel.dockerfile
@@ -12,13 +12,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     apt-utils \
     vim \
-    git
+    git \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # alias python='python3'
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
+# Install UV package manager
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.local/bin/:$PATH"
+
 # build with some basic python packages
-RUN pip install --no-cache-dir \
+RUN uv pip install --no-cache-dir \
+    --system \
+    --extra-index-url https://download.pytorch.org/whl/cu124 \
     numpy \
     torch \
     torchvision \

--- a/base-devel.dockerfile
+++ b/base-devel.dockerfile
@@ -28,7 +28,6 @@ ENV PATH="/root/.local/bin/:$PATH"
 # build with some basic python packages
 RUN uv pip install --no-cache-dir \
     --system \
-    --extra-index-url https://download.pytorch.org/whl/cu124 \
     numpy \
     torch \
     torchvision \

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -11,13 +11,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     apt-utils \
     vim \
-    git
+    git \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # alias python='python3'
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
+# Install UV package manager
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.local/bin/:$PATH"
+
 # build with some basic python packages
-RUN pip install --no-cache-dir \
+RUN uv pip install --no-cache-dir \
+    --system \
+    --extra-index-url https://download.pytorch.org/whl/cu124 \
     numpy \
     torch \
     torchvision \

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -27,7 +27,6 @@ ENV PATH="/root/.local/bin/:$PATH"
 # build with some basic python packages
 RUN uv pip install --no-cache-dir \
     --system \
-    --extra-index-url https://download.pytorch.org/whl/cu124 \
     numpy \
     torch \
     torchvision \


### PR DESCRIPTION
This PR adds `uv` as package manager for faster installs.

On my computer, capped to 40 MiB of download speed, build times go from 4 minutes and 20 seconds to 2 minutes and 15 seconds, almost 2 times faster.

Also, I pointed the install to an appropiate pytorch index and removed apt lists for smaller image size. 
Previously, base image size was 6.16GB and now its 5.79GB